### PR TITLE
qcom-cpufreq: Use CLKFLAG_NO_RATE_CACHE 

### DIFF
--- a/drivers/cpufreq/qcom-cpufreq.c
+++ b/drivers/cpufreq/qcom-cpufreq.c
@@ -447,9 +447,7 @@ static int msm_cpufreq_probe(struct platform_device *pdev)
 			return PTR_ERR(c);
 		else if (IS_ERR(c))
 			c = cpu_clk[cpu-1];
-#ifdef CONFIG_COMMON_CLK_MSM
 		c->flags |= CLKFLAG_NO_RATE_CACHE;
-#endif
 		cpu_clk[cpu] = c;
 	}
 	hotplug_ready = true;


### PR DESCRIPTION
After a CPU comes online, clk_set_rate() silently refuses to change said CPU's
frequency to the frequency it was running at before going offline (since it
thinks that we are setting the same frequency redundantly). By default, each CPU
runs at its minimum frequency when coming online, so if the governor decides to
keep a CPU running at the frequency it used before going offline, then
clk_set_rate() will ignore the frequency change request and the CPU will stay
stuck running at its minimum frequency for a potentially long period of time
(i.e. until the governor decides to change the frequency to something
different). This can cause severe lag when a device is woken up from deep sleep.

In order to prevent a CPU from being stuck at its default frequency for a
potentially long period of time, set the CLKFLAG_NO_RATE_CACHE flag so that the
governor's frequency change requests will always be honored right after a CPU
comes online.

Note that this requires a CPU's component clocks to be using CLKFLAG_NO_RATE_CACHE
as well in order to fix the issue.

Change-Id: I96b7d92b9fb92863724200c7272926f49d6dcfb8
Signed-off-by: Sultan Alsawaf <sultanxda@gmail.com>
Signed-off-by: khusika <khusikadhamar@gmail.com>
Signed-off-by: Lau <laststandrighthere@gmail.com>
Signed-off-by: prorooter007 <shreyashwasnik112@gmail.com>